### PR TITLE
Avoid sudo requirement in entrypoint

### DIFF
--- a/full-entrypoint.sh
+++ b/full-entrypoint.sh
@@ -10,8 +10,8 @@ until pg_isready -U postgres >/dev/null 2>&1; do
   sleep 1
 done
 # setup database and user password
-sudo -u postgres psql -c "ALTER USER postgres PASSWORD 'postgres'" || true
-sudo -u postgres psql -tc "SELECT 1 FROM pg_database WHERE datname='asa_maps'" | grep -q 1 || sudo -u postgres psql -c 'CREATE DATABASE asa_maps'
+runuser -u postgres -- psql -c "ALTER USER postgres PASSWORD 'postgres'" || true
+runuser -u postgres -- psql -tc "SELECT 1 FROM pg_database WHERE datname='asa_maps'" | grep -q 1 || runuser -u postgres -- psql -c 'CREATE DATABASE asa_maps'
 # start node backend
 node /app/backend.js &
 # start nginx in foreground


### PR DESCRIPTION
## Summary
- replace `sudo -u postgres` calls with `runuser` so the full Docker image does not require sudo

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6872749cf0348323b3d25b958939dde5