### PR TITLE
Fix parseCoords for missing values

### DIFF
--- a/backend.js
+++ b/backend.js
@@ -77,6 +77,7 @@ function parseLine(line){
 }
 
 function parseCoords(str){
+  if (!str || typeof str !== 'string') return [];
   str = str.trim();
   if (!str.startsWith('[')) return [];
   str = str.slice(1,-1);


### PR DESCRIPTION
## Summary
- guard `parseCoords` in `backend.js` against undefined or non-string inputs

## Testing
- `node - <<'NODE'
function parseCoords(str){ if(!str || typeof str !== 'string') return []; str=str.trim(); if (!str.startsWith('[')) return []; str=str.slice(1,-1); if(!str) return []; return str.split('),').map(p=>{ p=p.replace(/[()\[\]]/g,'').trim(); const [a,b]=p.split(',').map(Number); return [a,b]; });}
console.log('undefined:',JSON.stringify(parseCoords(undefined)));
console.log('empty:',JSON.stringify(parseCoords('')));
console.log('list:',JSON.stringify(parseCoords('[ (1,2), (3,4)]')));
NODE


------
https://chatgpt.com/codex/tasks/task_b_687283b28de4832c8a5fbed6ae8f770e