### PR TITLE
Update helper scripts to install express & pg

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Run the helper script for your platform to install Node.js and other tools:
 ./install_deps_windows.ps1   # Windows
 ```
 
-These scripts install Node.js 18 (via your package manager), npm and `jq`, then run `npm install` to fetch the required packages.
+These scripts install Node.js 18 (via your package manager), npm and `jq`, then run `npm install express pg` to fetch the required packages.
 
 ### Docker Compose
 

--- a/install_deps_linux.sh
+++ b/install_deps_linux.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 sudo apt-get update
 curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
 sudo apt-get install -y nodejs jq
-npm install
+npm install express pg

--- a/install_deps_macos.sh
+++ b/install_deps_macos.sh
@@ -2,4 +2,4 @@
 set -euo pipefail
 brew update
 brew install node jq
-npm install
+npm install express pg

--- a/install_deps_windows.ps1
+++ b/install_deps_windows.ps1
@@ -1,2 +1,2 @@
 choco install -y nodejs jq
-npm install
+npm install express pg


### PR DESCRIPTION
## Summary
- use `npm install express pg` across all helper scripts
- document new install step in README

## Testing
- `shellcheck install_deps_linux.sh install_deps_macos.sh install_deps_windows.ps1`

------
https://chatgpt.com/codex/tasks/task_b_68733cd57330832c9fc39b0381fa99cd